### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 ## Description
 A Model Context Protocol (MCP) server for interacting with the Cooper Hewitt Museum's collection API. This tool allows searching and retrieving detailed information about museum objects programmatically.
 
+<a href="https://glama.ai/mcp/servers/hwkfkqvpq7"><img width="380" height="200" src="https://glama.ai/mcp/servers/hwkfkqvpq7/badge" alt="cooper-hewitt-mcp MCP server" /></a>
+
 ## Prerequisites
 - Node.js (version 16+ recommended)
 - npm (Node Package Manager)


### PR DESCRIPTION
This PR adds a badge for the [cooper-hewitt-mcp](https://glama.ai/mcp/servers/hwkfkqvpq7) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/hwkfkqvpq7"><img width="380" height="200" src="https://glama.ai/mcp/servers/hwkfkqvpq7/badge" alt="cooper-hewitt-mcp MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.