### PR TITLE
Add image support with React components

### DIFF
--- a/src/components/ObjectDisplay.tsx
+++ b/src/components/ObjectDisplay.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { CooperHewittObject } from '../types';
+
+interface ObjectDisplayProps {
+  object: CooperHewittObject;
+}
+
+const ObjectDisplay: React.FC<ObjectDisplayProps> = ({ object }) => {
+  if (!object) return null;
+
+  const imageUrl = object.images?.[0]?.b?.url;
+  
+  return (
+    <Card className="w-full max-w-2xl mx-auto">
+      <CardHeader>
+        <CardTitle>{object.title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          {imageUrl && (
+            <div className="relative w-full h-96">
+              <img 
+                src={imageUrl} 
+                alt={object.title || 'Object image'}
+                className="object-contain w-full h-full"
+              />
+            </div>
+          )}
+          <div className="space-y-2">
+            {object.department && (
+              <p className="text-sm">Department: {object.department}</p>
+            )}
+            {object.medium && (
+              <p className="text-sm">Medium: {object.medium}</p>
+            )}
+            {object.date && (
+              <p className="text-sm">Date: {object.date}</p>
+            )}
+            {object.description && (
+              <p className="text-sm mt-4">{object.description}</p>
+            )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default ObjectDisplay;

--- a/src/components/ObjectsGrid.tsx
+++ b/src/components/ObjectsGrid.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Card, CardContent } from '@/components/ui/card';
+import { CooperHewittObject } from '../types';
+
+interface ObjectsGridProps {
+  objects: CooperHewittObject[];
+}
+
+const ObjectsGrid: React.FC<ObjectsGridProps> = ({ objects }) => {
+  if (!objects || objects.length === 0) return null;
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      {objects.map((object) => {
+        const imageUrl = object.images?.[0]?.b?.url;
+        
+        return (
+          <Card key={object.id} className="w-full">
+            <CardContent className="p-4">
+              {imageUrl && (
+                <div className="relative w-full h-48 mb-2">
+                  <img
+                    src={imageUrl}
+                    alt={object.title || 'Object image'}
+                    className="object-cover w-full h-full rounded"
+                  />
+                </div>
+              )}
+              <h3 className="text-lg font-medium truncate">{object.title}</h3>
+              {object.date && (
+                <p className="text-sm text-gray-500">{object.date}</p>
+              )}
+            </CardContent>
+          </Card>
+        );
+      })}
+    </div>
+  );
+};
+
+export default ObjectsGrid;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,17 @@
+export interface CooperHewittImage {
+  b: {
+    url: string;
+    width: number;
+    height: number;
+  };
+}
+
+export interface CooperHewittObject {
+  id: string;
+  title: string;
+  images?: CooperHewittImage[];
+  department?: string;
+  medium?: string;
+  date?: string;
+  description?: string;
+}


### PR DESCRIPTION
This PR adds support for displaying images from the Cooper Hewitt collection in the MCP server responses.

Changes include:
- Added types for Cooper Hewitt objects and images
- Created ObjectDisplay component for single object view
- Created ObjectsGrid component for displaying multiple objects
- Added TypeScript types and interfaces

The components use Tailwind CSS for styling and are designed to be responsive.

To use these components, update your server response handlers to return them as React artifacts when responding to search or get-object requests.

Example usage:
```typescript
return {
  artifact: {
    type: "application/vnd.ant.react",
    content: {
      component: "ObjectDisplay",
      props: { object }
    }
  }
};
```
